### PR TITLE
add all-contributors as a dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+node_modules/
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "transcripts",
+  "description": "Changelog episode transcripts in Markdown format",
+  "scripts": {
+    "contributors:add": "all-contributors add",
+    "contributors:generate": "all-contributors generate"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thechangelog/transcripts.git"
+  },
+  "license": "CC-BY-4.0",
+  "bugs": {
+    "url": "https://github.com/thechangelog/transcripts/issues"
+  },
+  "homepage": "https://github.com/thechangelog/transcripts#readme",
+  "devDependencies": {
+    "all-contributors-cli": "^4.10.0"
+  }
+}


### PR DESCRIPTION
Seems a bit excessive for a bunch of markdown files to specify dependencies, but this will make it a bit easier to keep the contributors up-to-date without needing `all-contributors-cli` installed globally.