### PR TITLE
Fix unintelligible in the-changelog-284

### DIFF
--- a/podcast/the-changelog-284.md
+++ b/podcast/the-changelog-284.md
@@ -427,7 +427,7 @@ So I guess I'd say there are a lot of different ways to get time on the machines
 
 **Jerod Santo:** Sharks with clicking laser beams on their heads... I told you our justification already.
 
-**Todd Gamblin:** \[unintelligible 01:02:00.26\] 
+**Todd Gamblin:** Ill-tempered sea bass.
 
 **Adam Stacoviak:** Oh, boy... \[laughter\]
 


### PR DESCRIPTION
Hard one to transcribe, although seems like a reference to [Austin Powers](https://www.cinemablend.com/news/1652182/why-dr-evil-has-ill-tempered-sea-bass-in-austin-powers).