### PR TITLE
Remove unintelligibles and add external links

### DIFF
--- a/gotime/go-time-3.md
+++ b/gotime/go-time-3.md
@@ -8,7 +8,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Carlisia Pinto:** Hello everybody.
 
-**Erik St. Martin:** And we have a special guest today, long time Go community member - and I mean LONG time Go community member - he's got a great beard, and he's also the CTO and co-founder of Iron.io. We have Travis Reeder here, tell everybody hello, Travis.
+**Erik St. Martin:** And we have a special guest today, long time Go community member - and I mean _long_ time Go community member - he's got a great beard, and he's also the CTO and co-founder of Iron.io. We have Travis Reeder here, tell everybody hello, Travis.
 
 **Travis Reeder:** Hello.
 
@@ -18,7 +18,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Erik St. Martin:** No way, nobody does that.
 
-**Brian Ketelsen:** Yeah... The compiler slowed down a little bit in Go 1.6, and I saw a tweet from Dave Cheney recently that showed that one of the most recent commits cut compile times - I'm looking at his \[unintelligible 00:01:29.02\] graph, it looks to me like it cut about 40%, so we're getting much closer back to Go 1.4 compile times, which we knew would happen and I'm very excited to see. Hopefully when 1.7 ships, the compile pain won't be as bad as it was before. That's a really big event for all of us, so thank you for everybody on the compiler team - Rob Griesemer, \[unintelligible 00:01:52.20\], thanks for doing that for us, we appreciate it.
+**Brian Ketelsen:** Yeah... The compiler slowed down a little bit in Go 1.6, and I saw a tweet from Dave Cheney recently that showed that one of the most recent commits cut compile times - I'm looking at his [juju](https://github.com/juju/juju) graph, it looks to me like it cut about 40%, so we're getting much closer back to Go 1.4 compile times, which we knew would happen and I'm very excited to see. Hopefully when 1.7 ships, the compile pain won't be as bad as it was before. That's a really big event for all of us, so thank you for everybody on the compiler team - Rob Griesemer, you rock, thanks for doing that for us, we appreciate it.
 
 **Erik St. Martin:** Yeah, I think that that was kind of a public thing, when they converted the compiler to Go, because a lot of it was kind of done through code generation that we all knew that that would happen. But it's great to see the performance come back. Is that part of 1.7? Is that locked into that release, or is this just a commit that's kind of hanging?
 
@@ -68,7 +68,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Erik St. Martin:** My thought on Ruby these days is pretty similar to my thought on Java. It's not that I don't like the languages, I don't like the way people write the language. Ruby and Rails have been great, but these huge monolithic coupled together things because people just throw it together because they can, and then it becomes hard to support.
 
-**Carlisia Pinto:** Yeah. And this question that you asked, Erik, reminded me of the question we were throwing around last week about whether we optimize for performance, and I think Travis should be the expert here - I am wondering, Travis, how do you plan for performance loads that \[unintelligible 00:07:21.15\] in the future? How much pre-planning goes into identifying the \[unintelligible 00:07:27.27\] need to be performant in the future? Because I think a lot of times we go about saying, "Well, I don't need this more efficient technology because my app is never going to need that much performance", and on the other hand... Sometimes you know beforehand, but sometimes you don't know and you need to figure it out. So how does that go?
+**Carlisia Pinto:** Yeah. And this question that you asked, Erik, reminded me of the question we were throwing around last week about whether we optimize for performance, and I think Travis should be the expert here - I am wondering, Travis, how do you plan for performance loads that you update in the future? How much pre-planning goes into identifying the spaces need to be performant in the future? Because I think a lot of times we go about saying, "Well, I don't need this more efficient technology because my app is never going to need that much performance", and on the other hand... Sometimes you know beforehand, but sometimes you don't know and you need to figure it out. So how does that go?
 
 **Travis Reeder:** It's impossible to predict, right? We didn't know what we would need upfront, that's why we went from Ruby and had to switch to Go. But nowadays we do have a better idea of what we need, and we just always try to push the limit. There is a recent blog post on our blog.iron.io about getting a million messages per second on IronMQ. So we're pushing it; we have no customers that are doing that kind of speed, but we try to push and hit milestones like that, so that if a customer needs that... We're always ahead of what our customers would need.
 
@@ -86,7 +86,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Erik St. Martin:** And CockroachDB is written on top of RocksDB, too. It basically is implementing some of Google Spanners paper, mixed with some other stuff, but that's all in Go, and then their file system layer is done with RocksDB.
 
-**Travis Reeder:** Yeah, I like that Cockroach project, I don't know where it's at now; it was pretty early last time I checked, but we basically did the same thing for IronMQ - we took Rocks as the persistence layer, which is super fast. It's nice for a queue too, because all the data is sorted; it kind of worked out really nice. And then we had to build a networking and replication, and \[unintelligible 00:09:40.19\] scaling on top of Rocks, basically.
+**Travis Reeder:** Yeah, I like that Cockroach project, I don't know where it's at now; it was pretty early last time I checked, but we basically did the same thing for IronMQ - we took Rocks as the persistence layer, which is super fast. It's nice for a queue too, because all the data is sorted; it kind of worked out really nice. And then we had to build a networking and replication, and failover, and scaling on top of Rocks, basically.
 
 **Erik St. Martin:** Did you end up using Raft for your consensus protocol?
 
@@ -106,7 +106,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Erik St. Martin:** And I hope that he curates it first, because I don't have that kind of time.
 
-**Brian Ketelsen:** I do, I only share the interesting ones. The first one today I saw a couple months ago and it was just in its beginnings, but it looks like it's getting pretty nice - there is an Oauth2 server, written by Richard Knop. It's called go-oauth2-server, and it looks like it's getting pretty solid in terms of its capabilities. It's a standalone server, it's backed by \[unintelligible 00:11:11.09\] for configuration and I think postgres for data storage. It gives you the full Oauth2 flows for your apps, and it generates keys, the whole work, so it looks like something that's well worth checking out. Links to that of course will be in the show notes.
+**Brian Ketelsen:** I do, I only share the interesting ones. The first one today I saw a couple months ago and it was just in its beginnings, but it looks like it's getting pretty nice - there is an Oauth2 server, written by Richard Knop. It's called go-oauth2-server, and it looks like it's getting pretty solid in terms of its capabilities. It's a standalone server, it's backed by [etcd](https://coreos.com/etcd/) for configuration and I think postgres for data storage. It gives you the full Oauth2 flows for your apps, and it generates keys, the whole work, so it looks like something that's well worth checking out. Links to that of course will be in the show notes.
 
 **Carlisia Pinto:** It has wonderful documentation.
 
@@ -144,7 +144,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Brian Ketelsen:** Oauth, actually. You can query directly against the SQLiteDB on disk, and I think you're required to do all your data changes over the HTTP API, which actually just sends DDL. So the API is a really tiny JSON wrapper for DDL.
 
-**Erik St. Martin:** So the downside is just that you can't just use a normal SQLite adapter, you kind of have to develop HTTP client to start your data, but still... It's really interesting though, because things like Raft, \[unintelligible 00:13:39.17\] has really enabled people to build their own distributed systems much more easily. And to Travis' point too, they build on top of RocksDB for the persistence layer and leveraged graph, and they're doing their own distributed census internally, so you can kind of make up your own databases - not that you'd suggest everybody do that, but...
+**Erik St. Martin:** So the downside is just that you can't just use a normal SQLite adapter, you kind of have to develop HTTP client to start your data, but still... It's really interesting though, because things like Raft, and etcd, and console has really enabled people to build their own distributed systems much more easily. And to Travis' point too, they build on top of RocksDB for the persistence layer and leveraged graph, and they're doing their own distributed census internally, so you can kind of make up your own databases - not that you'd suggest everybody do that, but...
 
 **Brian Ketelsen:** Facebook did it with MongoDB. They took Mongo and stuffed Rocks underneath it, and have an extremely fast and fault-tolerant and high-performant database system. I think -- is it Charity Majors that heads that up? I can't remember, but anyway... Everybody's doing it, and it's cool.
 
@@ -156,7 +156,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Brian Ketelsen:** ...it's still there.
 
-**Travis Reeder:** I wonder if it's dead though, now that \[unintelligible 00:14:36.16\] is dead.
+**Travis Reeder:** I wonder if it's dead though, now that Parse is dead.
 
 **Brian Ketelsen:** That's a good question.
 
@@ -246,7 +246,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Travis Reeder:** I have not, no.
 
-**Brian Ketelsen:** I added that I think last year. I love Viper. I think it's really awesome. We used the remote config as the baseline configuration. So things that every machine, every app needs to know comes from \[unintelligible 00:23:10.06\] and then you can just layer on extra stuff on top of that, and it worked out really nicely.
+**Brian Ketelsen:** I added that I think last year. I love Viper. I think it's really awesome. We used the remote config as the baseline configuration. So things that every machine, every app needs to know comes from etcd and then you can just layer on extra stuff on top of that, and it worked out really nicely.
 
 **Travis Reeder:** That's cool, yeah.
 
@@ -360,7 +360,7 @@ Okay, so episode number three. Today we have Brian on the call, why don't you ju
 
 **Erik St. Martin:** Because you really liked tweaking the JVM, and you wanted to do it again.
 
-**Travis Reeder:** I love it, yeah. So we looked at these things, Scala was kind of popular at the time too, and Clojure was kind of hip, too. But this Go thing was there, and we saw that Google was back and there were some really smart people behind it. We tried it, and I think the simplicity of the language, with almost same performance as Java - not quite, but close... We liked that, we prototyped really quickly, a \[unintelligible 00:34:25.06\] implementation basically, and tried to see what kind of performance we could push through it, and it worked really well.
+**Travis Reeder:** I love it, yeah. So we looked at these things, Scala was kind of popular at the time too, and Clojure was kind of hip, too. But this Go thing was there, and we saw that Google was back and there were some really smart people behind it. We tried it, and I think the simplicity of the language, with almost same performance as Java - not quite, but close... We liked that, we prototyped really quickly, a queue implementation basically, and tried to see what kind of performance we could push through it, and it worked really well.
 
 We had some convincing to do, our team and our investors, because you never want to pick the wrong technology, and we just moved forward with it. It turns out it was a really good decision, luckily.
 

--- a/gotime/go-time-5.md
+++ b/gotime/go-time-5.md
@@ -76,7 +76,7 @@ Alright everybody, welcome back for another episode of Go Time. This is episode 
 
 **Brian Ketelsen:** Yeah, so all you library developers out there, if you're not putting context as the first parameter of your public functions, now is a great time to start doing that, please. I wanted to say please, I don't wanna sound too bossy. I can come across that way sometimes.
 
-**Carlisia Pinto:** And from the little experience that I have with Go, I see a lot of times when people use other network packages just so they can get the context, and I would even do that, because \[unintelligible 00:05:11.01\] But now that it's in the library, I wonder how it's going to impact the usage of the external libraries. Or if people are just gonna have to keep adding more features to make it more attractive for people to use them.
+**Carlisia Pinto:** And from the little experience that I have with Go, I see a lot of times when people use other network packages just so they can get the context, and I would even do that, because I don't wanna do that stuff by hand. But now that it's in the library, I wonder how it's going to impact the usage of the external libraries. Or if people are just gonna have to keep adding more features to make it more attractive for people to use them.
 
 **Erik St. Martin:** But is it really a competition, though? I think at the end of the day it's about writing good quality software, that's readable, and I think that by having external libraries that people really like - and we kind of get consensus on these patterns - I think it's okay to pull that stuff in. Because not everybody's gonna be aware of these things, despite how much visibility we think they have, or as people find stuff in the standard library - that's generally where people look first, so I think it's a hard debate. We're kind of pulling away users from some standard library, but I think that the library owners are probably glad to see it there. I think it will get more love in the standard library, too.
 
@@ -108,7 +108,7 @@ Alright everybody, welcome back for another episode of Go Time. This is episode 
 
 **Carlisia Pinto:** Exactly.
 
-**Erik St. Martin:** \[unintelligible 00:08:58.29\] and stuff like that that runs all the suite of different tooling.
+**Erik St. Martin:** Like, there's a Go meta-linter and stuff like that that runs all the suite of different tooling.
 
 **Carlisia Pinto:** I can totally see that happening, too.
 
@@ -176,7 +176,7 @@ Alright everybody, welcome back for another episode of Go Time. This is episode 
 
 **Brian Ketelsen:** It is. I've seen projects that don't list themselves as the primary language that they are just because whatever GitHub uses to detect that was thwarted by maybe their directory layout, or whatever.
 
-**Erik St. Martin:** I'm not sure how that detection works. I mean, what percentage of the codebase is in what... Because if you had, say, \[unintelligible 00:17:15.02\] that's a bunch of Go, but it's a whole lot of web stuff too, HTML, CSS and Javascript too, so is there more of one than the other, then does that cause false positives .
+**Erik St. Martin:** I'm not sure how that detection works. I mean, what percentage of the codebase is in what... Because if you had, say, [Grafana](https://grafana.com/) that's a bunch of Go, but it's a whole lot of web stuff too, HTML, CSS and Javascript too, so is there more of one than the other, then does that cause false positives .
 
 **Carlisia Pinto:** I have always wondered that too, if somebody knows, please...
 
@@ -254,7 +254,11 @@ Alright everybody, welcome back for another episode of Go Time. This is episode 
 
 **Erik St. Martin:** So Sarah, one project that we would love to hear you talk about is your Test2Doc. That's really cool.
 
-**Brian Ketelsen:** Thanks. So I got this idea like a year and a half ago. I was maintaining a ReST API; I was working for a company called Sproutling, we were building a web baby monitor, so I was building a ReST API that had multiples clients. We had custom hardware, which was sort of a base station that was monitoring room temperature in the baby's room; we had an iOS app, which was the second client, and we had a web app, which was the third client. So we had multiple developer teams working on each of these, and since I was the only person responsible for the ReST API - well, not because of that, but I needed to have API documentation, of course. So I started using Apiary, because I liked the format. You can write it in markdown, and the API blueprint specification was open source, which is nice. For larger changes I kept adding an endpoint, or deleting an endpoint - those were easy to remember to update the documentation, but for smaller things like deleting an attribute, all the way down to deleting a column on a database table would trickle up to the endpoint change, which would mean the field was missing on the JSON response. Those smaller changes started to add up a lot, and so my documentation was often really inconsistent with the actual API. So I forked to a tool called Dread, which is meant for testing new documentation against your actual API. It was pretty good, but I had to periodically just run \[unintelligible 00:25:28.14\] and update all of the documentation. I started to get really frustrated, because my unit tests were all there; if only my fellow engineers could read my Go unit tests and the status documentation, that would have worked great. So I realized that all of the information that you need for API documentation is in the endpoint Hammer test, so I decided I was just gonna record the requests and responses as the test ran, and put them in a markdown file in the appropriate format, and then be able to generate all of my API documentation, host it, and have everything be automated, so I would never have to worry about out of date documentation and angry developers, people asking me questions and things like that. So that's sort of where that came from.
+**Sarah Adams:** Thanks. So I got this idea like a year and a half ago. I was maintaining a ReST API; I was working for a company called Sproutling, we were building a web baby monitor, so I was building a ReST API that had multiple clients. We had custom hardware, which was sort of a base station that was monitoring room temperature in the baby's room; we had an iOS app, which was the second client, and we had a web app, which was the third client. 
+
+So we had multiple developer teams working on each of these, and since I was the only person responsible for the ReST API - well, not because of that, but I needed to have API documentation, of course. So I started using [Apiary](https://apiary.io/), because I liked the format. You can write it in markdown, and the API blueprint specification was open source, which is nice. For larger changes I kept adding an endpoint, or deleting an endpoint - those were easy to remember to update the documentation, but for smaller things like deleting an attribute, all the way down to deleting a column on a database table would trickle up to the endpoint change, which would mean the field was missing on the JSON response. 
+
+Those smaller changes started to add up a lot, and so my documentation was often really inconsistent with the actual API. So I forked to a tool called [Dredd](http://dredd.org/en/latest/), which is meant for testing new documentation against your actual API. It was pretty good, but I had to periodically just run this and update all of the documentation. I started to get really frustrated, because my unit tests were all there; if only my fellow engineers could read my Go unit tests and the status documentation, that would have worked great. So I realized that all of the information that you need for API documentation is in the endpoint Hammer test, so I decided I was just gonna record the requests and responses as the test ran, and put them in a markdown file in the appropriate format, and then be able to generate all of my API documentation, host it, and have everything be automated, so I would never have to worry about out of date documentation and angry developers, people asking me questions and things like that. So that's sort of where that came from.
 
 **Brian Ketelsen:** So when you're writing your tests, how much differently do you write your tests to make the documents look appropriate? Do you have to...?
 
@@ -266,7 +270,7 @@ Alright everybody, welcome back for another episode of Go Time. This is episode 
 
 **Erik St. Martin:** That's really interesting. So how do you have that implemented? You're statically analyzing the tests?
 
-**Sarah Adams:** No... Actually this is what \[unintelligible 00:27:25.25\] a while ago. But I think I used the HTTP tests.
+**Sarah Adams:** No... Actually this is what - I wrote this bit a while ago. But I think I used the HTTP tests.
 
 **Erik St. Martin:** They're like response-recorders, and stuff like that?
 
@@ -292,7 +296,7 @@ Alright everybody, welcome back for another episode of Go Time. This is episode 
 
 **Brian Ketelsen:** Nice.
 
-**Carlisia Pinto:** I just thought about making this \[unintelligible 00:30:48.03\] or something, another tool... Make a diff between the pushes, so you can see like a change log version, that would be really cool.
+**Carlisia Pinto:** I just thought about making this - another tool... Make a diff between the pushes, so you can see like a change log version, that would be really cool.
 
 **Sarah Adams:** Yeah, that would be cool. And there are a lot of things that I wanna add to this. A couple people have requested Swagger support; I think that's probably more common that Apiary for API documentation.
 
@@ -314,7 +318,7 @@ Alright everybody, welcome back for another episode of Go Time. This is episode 
 
 **Sarah Adams:** Thanks!
 
-**Carlisia Pinto:** Yeah. The one issue I can see with trying to make it fit in with Swagger is that Swagger has a very... Well, it has a specification, so it's strict in that way, and if you design something that is not supported - not necessarily \[unintelligible 00:33:14.22\] but it's not supported by that spec version that you're working with, then it just doesn't work.
+**Carlisia Pinto:** Yeah. The one issue I can see with trying to make it fit in with Swagger is that Swagger has a very... Well, it has a specification, so it's strict in that way, and if you design something that is not supported - not necessarily, it wouldn't be ReSTful, but it's not supported by that spec version that you're working with, then it just doesn't work.
 
 **Sarah Adams:** Well, API Blueprint has a pretty strict spec also. You just have to match the data, you have to really evaluate the spec and match the data, fit it into the spec.
 

--- a/jsparty/js-party-13.md
+++ b/jsparty/js-party-13.md
@@ -30,7 +30,7 @@ Sometime mid early last year we decided that we're just gonna bite the bullet an
 
 **Rebecca Turner:** ...and we first started to actually see results -- I think you tried it out in late January...
 
-**Kat Marchán:** Late January, early February, that was when I could actually poking at it \[unintelligible 00:03:24.23\]
+**Kat Marchán:** Late January, early February, that was when I could actually do it.
 
 **Rebecca Turner:** ...and we were really surprised to find that it was unbelievably faster. The old cache was -- I still don't know how it was as slow as it was.
 
@@ -52,7 +52,7 @@ Probably the single biggest aspect of the speed in the new version is the new lo
 
 **Kat Marchán:** Now we're pretty much \[unintelligible 00:05:42.27\] developers, right?
 
-**Alex Sexton:** In that vein, one of the things I was excited to see was the symlink stuff... Stripe, where I work, has a monorepo and we definitely have some jiu-jitsu around trying to move libraries that are in our thing into our dependencies, but have dependencies still work among our subdependencies, all in the same repo, and the symlink stuff seems to solve a bunch of that. Can you explain how that works? I guess I did part of that, but \[unintelligible 00:06:18.03\]
+**Alex Sexton:** In that vein, one of the things I was excited to see was the symlink stuff... Stripe, where I work, has a monorepo and we definitely have some jiu-jitsu around trying to move libraries that are in our thing into our dependencies, but have dependencies still work among our subdependencies, all in the same repo, and the symlink stuff seems to solve a bunch of that. Can you explain how that works? I guess I did part of that, but I enjoyed that.
 
 **Rebecca Turner:** Sure! So we've had this file specifier since npm@2, so you could npm install a local directory. It was added in at the very end of the npm@2 development cycle, and it wasn't super well integrated into the rest of the npm product. What went into the shrinkwrap was never fully specified and has varied over time in various bad ways, because when it was originally put in, the fact that it even worked in shrinkwrap was kind of an accident.
 
@@ -82,7 +82,7 @@ When we were working on designing npm@5, one of the things we wanted to do was t
 
 **Kat Marchán:** Yeah, the --cache-max 0...?
 
-**Rebecca Turner:** No, because it's \[unintelligible 00:09:27.01\]
+**Rebecca Turner:** No, because it's still 304 checks. --cache-max 0 would make it not even 304 check.
 
 **Kat Marchán:** Right, right. So we have stuff on the pipeline now, things like... I've talked about --low-mem, which I need to spec out and hopefully get in something like that.
 
@@ -102,7 +102,7 @@ When we were working on designing npm@5, one of the things we wanted to do was t
 
 **Alex Sexton:** I think one of the primary overarching stories behind a lot of this is most people do a thing, and they do that thing and they're like "How come npm doesn't do this?" and I think no one's invoked the "yarn" word yet, but I think a lot of what yarn was was "Hey, there's this use case that if we take away all these other constraints that npm has and all these other things that they have to do, then we can do this other thing very quickly, and add some features." It seems like a primary story of npm is that there are a lot of different use cases and continuing to support all those has very unique challenges in places that people don't even consider.
 
-**Kat Marchán:** Yeah, I mean npm is the default, and that means that we have to support all these people; not just new people that are coming in, but what five, six years of people who have old setups and don't wanna have their keys moved too much. Although that's the \[unintelligible 00:11:27.29\] conversation yesterday.  Maybe that's a bit of a weird metaphor at this point, but I think it's okay for npm to make tradeoffs that other things can't. We're not gonna sacrifice the user base that we have in order to primarily serve what developers -- so we can serve both, and that's what we'll do... We'll optimize for like spreading out...
+**Kat Marchán:** Yeah, I mean npm is the default, and that means that we have to support all these people; not just new people that are coming in, but what five, six years of people who have old setups and don't wanna have their keys moved too much. Although that's the - \[laughter\] we had a conversation yesterday.  Maybe that's a bit of a weird metaphor at this point, but I think it's okay for npm to make tradeoffs that other things can't. We're not gonna sacrifice the user base that we have in order to primarily serve what developers -- so we can serve both, and that's what we'll do... We'll optimize for like spreading out...
 
 Another aspect of npm@5 is that it is probably our most significant step in a while towards breaking npm down into significant chunks, with the intention of -- like, the dream here is to (the platonic idea, if you will) be able to take all the components that npm uses right now, pick only the ones that you like and need, and then cook up your own package manager for your particular community.
 
@@ -124,7 +124,7 @@ It's why we never integrated any kind of flat install like Bower would do. We're
 
 **Rebecca Turner:** We would hope that people would be able to build on our tools to make that, if they wanted a package manager that did that.
 
-**Kat Marchán:** Yes. And \[unintelligible 00:14:32.19\] have basically about that literally just wraps the \[unintelligible 00:14:32.19\] and that's the flat tree.
+**Kat Marchán:** Yes. And we, fantastically, have basically about that literally just wraps the \[unintelligible 00:14:32.19\] and that's the flat tree.
 
 **Rebecca Turner:** I mean, that's very hard... \[laughter\]
 
@@ -186,7 +186,9 @@ The npm lockfile stores exactly how your Node modules should look when it's done
 
 **Rebecca Turner:** Or "Download this tarball and extract it here", and some of that includes Node modules.
 
-**Rachel White:** \[unintelligible 00:21:04.27\] does that in various ways.
+**Alex Sexton:** I see.
+
+**Rachel White:** Notably, \[unintelligible 00:21:04.27\] does that in various ways.
 
 **Rebecca Turner:** Yeah... Those, of course, don't affect the modules.
 
@@ -208,7 +210,7 @@ The npm lockfile stores exactly how your Node modules should look when it's done
 
 This is something that affects pretty much every package manager in existence pretty much.
 
-**Rebecca Turner:** I mean, everyone that doesn't essentially have an editorial board accepting packages. \[unintelligible 00:23:18.24\] package managers tend to have that. If you wanna get something into Debian, people are going to look at it before you put it in. But if you wanna publish something to PyPy or RubyGems, or the CPad. No one's gonna look at that; that code is not vetted. There is no approval process, so it can have anything.
+**Rebecca Turner:** I mean, everyone that doesn't essentially have an editorial board accepting packages. So OS package managers tend to have that. If you wanna get something into Debian, people are going to look at it before you put it in. But if you wanna publish something to PyPy or RubyGems, or the CPad. No one's gonna look at that; that code is not vetted. There is no approval process, so it can have anything.
 
 **Kat Marchán:** We do have some stuff on the pipeline which I actually don't know if I can talk about, because that's registry stuff and that's not my circus, not my monkeys, but we do have stuff to prevent the infamous worms that people are worried about. So at least automated self-publishing worms will be mitigated. They might rimraf your read directory, but it will only be your read directory, and that's great.
 
@@ -218,7 +220,7 @@ This is something that affects pretty much every package manager in existence pr
 
 **Rebecca Turner:** And they keep asking for more...
 
-**Kat Marchán:** \[unintelligible 00:25:03.19\] Can you stop? \[laughs\]
+**Kat Marchán:** I know, it's like, "Can you stop?" \[laughs\]
 
 **Mikeal Rogers:** We're coming up on the end of the segment here, but we've talked a ton about all the reasons why you should be installing npm@5 right now, today... Because it's awesome. Is there anybody that needs to worry about installing npm@5? Any kind of breaks that people might be reliant on out there that you would say "You know what? Hold off for a second...", or is it just everybody should go get it today?
 
@@ -226,13 +228,13 @@ This is something that affects pretty much every package manager in existence pr
 
 As with any major release of a tool this core, I would say that you try it, you see how it works for your setup. It might work very work very well for your setup, or there might be things that still need updating. If there are things that still need updating, let us know, we'll get to that. But this is just something that applies to pretty much any software that goes through a major release.
 
-**Rebecca Turner:** As far as things that we intentionally broke - the breaking changes of npm@5, most of those are things like the save by default and the lockfile, and the fact that output is no longer five miles long. I like that one... That one's nice. We have a little summary \[unintelligible 00:26:44.10\]
+**Rebecca Turner:** As far as things that we intentionally broke - the breaking changes of npm@5, most of those are things like the save by default and the lockfile, and the fact that output is no longer five miles long. I like that one... That one's nice. We have a little summary now.
 
 **Kat Marchán:** Yeah... Apart from people relying on things that they really shouldn't have been relying on, like very specific parts of the ouput, there's not a lot that will change, especially not for consumers of packages. A lot of this is mostly on the developer end.
 
 **Alex Sexton:** If you currently have a shrinkwrap, do you need to generate a new shrinkwrap with 5?
 
-**Kat Marchán:** No. We will probably -- in the case of most shrinkwraps; I don't know if all shrinkwraps in existence... But we will update that on run. One thing to note is that npm-shrinkwrap and package-lock.json are the same format. The main difference is that npm-shrinkwrap is publishable and package-lock is not. Shrinkwrap is meant for things that you really absolutely need to guarantee \[unintelligible 00:27:28.16\] for people who install your package. So we automatically read that we'll use it, and then we'll write it back out in the new format.
+**Kat Marchán:** No. We will probably -- in the case of most shrinkwraps; I don't know if all shrinkwraps in existence... But we will update that on run. One thing to note is that npm-shrinkwrap and package-lock.json are the same format. The main difference is that npm-shrinkwrap is publishable and package-lock is not. Shrinkwrap is meant for things that you really absolutely need to guarantee an exact read for people who install your package. So we automatically read that we'll use it, and then we'll write it back out in the new format.
 
 The thing to note is if you keep it called npm-shrinkwrap, older versions of npm down to like npm@2 will be able to install it; not npm@1, because of scope packages, but all the way down to 2 you should be able to get identical trees pretty much.
 
@@ -334,7 +336,11 @@ If you remix this Glitch site, you get a blank Sheetsee setup and it just writes
 
 **Alex Sexton:** Well, it would need to cache -- I don't know, syncing data versus caching requests are kind of two separate things.
 
-**Mikeal Rogers:** Yeah, I see what you're saying. \[unintelligible 00:40:47.07\] I'm playing with demos right now, I'm sorry... \[laughter\] I'm playing with Sheetsee demos in the background.
+**Mikeal Rogers:** Yeah, I see what you're saying. 
+
+**Jessica Lord:** Cool!
+
+**Mikeal Rogers:** I'm playing with demos right now, I'm sorry... \[laughter\] I'm playing with Sheetsee demos in the background.
 
 **Rachel White:** Is there anything else that you would like to add to Sheetsee that it doesn't have right now?
 
@@ -356,7 +362,7 @@ If you remix this Glitch site, you get a blank Sheetsee setup and it just writes
 
 **Jessica Lord:** Yeah.
 
-**Mikeal Rogers:** One of the things that I love about this is I feel like all Javascript tooling that I've used in the last 2-3 years has been a giant compile chain and it integrates into a giant compile chain, and this was like "Oh, back in the days..." where you could just insert a "script include" and then do stuff \[unintelligible 00:42:09.20\] It's like, "Oh yeah, there's actually cases where this is just so much simpler..."
+**Mikeal Rogers:** One of the things that I love about this is I feel like all Javascript tooling that I've used in the last 2-3 years has been a giant compile chain and it integrates into a giant compile chain, and this was like "Oh, back in the days..." where you could just insert a "script include" and then do stuff in the body. It's like, "Oh yeah, there's actually cases where this is just so much simpler..."
 
 **Jessica Lord:** Yeah...
 
@@ -384,7 +390,7 @@ I remember very specifically searching in Altavista and saying "Way to get infor
 
 **Mikeal Rogers:** Alright, Rachel's gonna go first... \[laughs\]
 
-**Rachel White:** I just don't want anybody else to pick my pick. My pick of the week is a really interesting repository that someone e-mailed me about and I ignored at first, but then other people did not ignore it and now it's got a bunch of stars on GitHub. It's called Chaosbot, and it's a social coding experiment that updates its own code democratically based on what the people that are involved with the project do. You can vote on things in order to get PRs merged.
+**Rachel White:** I just don't want anybody else to pick my pick. My pick of the week is a really interesting repository that someone e-mailed me about and I ignored at first, but then other people did not ignore it and now it's got a bunch of stars on GitHub. It's called [Chaosbot](https://github.com/Chaosthebot/Chaos), and it's a social coding experiment that updates its own code democratically based on what the people that are involved with the project do. You can vote on things in order to get PRs merged.
 
 I guess IIT reminds me of TwitchPlaysPokemon or like TwitchBuildsAComputer or TwitchInstallsLinux, because the fate of the project is at the whim of the people controlling it. I think it will be really interesting to see what they end up making with it.
 
@@ -394,7 +400,7 @@ I guess IIT reminds me of TwitchPlaysPokemon or like TwitchBuildsAComputer or Tw
 
 **Mikeal Rogers:** I think my favorite thing here is that they have a death counter... People hack it to merge things that actually break it with the voting mechanism, and they're really upfront about how many times the trunk has died because of this...
 
-**Rachel White:** Yeah... My favorite change that got made was this guy got a PR in so that there was no voting weight on the voting, and he was the sole person that could make decisions, which was pretty cool. \[laughter\]
+\[unintelligible 00:50:27.28\]**Rachel White:** Yeah... My favorite change that got made was this guy got a PR in so that there was no voting weight on the voting, and he was the sole person that could make decisions, which was pretty cool. \[laughter\]
 
 Yeah, I don't know... If you look at the issues, or -- I think it's in the main part... If you scroll down and...
 
@@ -410,23 +416,23 @@ Yeah, I don't know... If you look at the issues, or -- I think it's in the main 
 
 **Alex Sexton:** Wait, I just wanted to mention that I searched for Chaosbot and the first result is on the Sonic News Network - as in Sonic the Hedgehog - Wikipedia... They have their own wiki on sonic.wikia.com, and apparently there's a Chaosbot in Sonic X \#28, which is a comic... So that's the true Chaosbot.
 
-\[00:48:16.03\] My pick for this week is Babili. Is that how it's pronounced? \[unintelligible 00:48:24.21\] If you type its name into the say command, it will pronounce it correctly, apparently. It is Babel-Minify. Stripe, for instance, likes on its website only to ship ES6 code that works in all the browsers that everyone visits our site it, and it's kind of like a fun thing where you can push just real ES6 out without compiling it down with Babel, or anything like that, and it's cool. But the bad thing about shipping ES6 code is none of the current minifiers support ES6, so if you throw ES6 code, it will fail. So you have to compile down to ES5 and then you can minify.
+\[00:48:16.03\] My pick for this week is [Babili](https://www.npmjs.com/package/babili). I believe that's that how it's pronounced... If you type its name into the say command, it will pronounce it correctly, apparently. It is Babel-Minify. Stripe, for instance, likes on its website only to ship ES6 code that works in all the browsers that everyone visits our site it, and it's kind of like a fun thing where you can push just real ES6 out without compiling it down with Babel, or anything like that, and it's cool. But the bad thing about shipping ES6 code is none of the current minifiers support ES6, so if you throw ES6 code, it will fail. So you have to compile down to ES5 and then you can minify.
 
 So I think Babili is the first attempt at an ES6 minifier. It will minify down to the same syntax, just smaller, and whatever. It's still in beta 0.0.1, which is pretty beta... But for small things, I think it's probably pretty safe. They have some tests against some common open source things that appear to work still as well. So if you are interested in shipping ES 2015 to the browser, it's a good thing to start looking into. I imagine this type of thing will get much more popular.
 
 **Mikeal Rogers:** Yeah, I'm using it in I think like five projects, and only one of them, some module somewhere is doing something that it actually breaks on. It ends up outputting something that is not valid. But that was like six months ago; that may be a bug that was fixed. I tried to track it down, but tracking down bugs in minifiers is incredibly difficult, it turns out, so I kind of gave up on trying to debug it at that point... But I'm really happy with it in the other projects that I'm using it in.
 
-If you're doing WebRTC experiments, it's easy to just ship ES6 to the browser, because the Venn diagram of browsers that support WebRTC and don't support ES6 features is not a thing. \[unintelligible 00:50:27.28\]
+If you're doing WebRTC experiments, it's easy to just ship ES6 to the browser, because the Venn diagram of browsers that support WebRTC and don't support ES6 features is not a thing. They're basically the same.
 
 **Alex Sexton:** That's decently true of the animations in CSS that's written for a lot of the Stripe sites, so it's mostly the thinking is you already have a broken experience, so...
 
-**Mikeal Rogers:** Yeah, it's perfect. Okay, my project of the week is called pkg. It's from Zeit; they're the creators of Now and Hyper and a bunch of other awesome stuff. It's Guillermo Rauch's new company, who started Socket.io. Pkg is something that I've wanted for a long time, which is basically take all of your Node projects - your code, all your dependencies, everything - and Node itself and turn that into one single executable file, so that somebody can go and take that and run it on a similar environment. If you have native dependencies, it's gonna have to be on the same architecture, I would imagine... But they could just go and run that wherever.
+**Mikeal Rogers:** Yeah, it's perfect. Okay, my project of the week is called [pkg](https://www.npmjs.com/package/pkg). It's from Zeit; they're the creators of [Now](https://zeit.co/now) and [Hyper](https://hyper.is/) and a bunch of other awesome stuff. It's Guillermo Rauch's new company, who started Socket.io. Pkg is something that I've wanted for a long time, which is basically take all of your Node projects - your code, all your dependencies, everything - and Node itself and turn that into one single executable file, so that somebody can go and take that and run it on a similar environment. If you have native dependencies, it's gonna have to be on the same architecture, I would imagine... But they could just go and run that wherever.
 
 This is something that Go has had since day one, they designed it for this, but this has always been kind of a challenge with Node. They have got it working apparently, so I'm really, really excited about this.
 
 Jessica, do you have a pick for us?
 
-**Jessica Lord:** I do... \[laughs\] You'll have to just google this, so I don't have to read out the URL... It's a Medieval Fantasy City Generator. \[laughter\]
+**Jessica Lord:** I do... \[laughs\] You'll have to just google this, so I don't have to read out the URL... It's a [Medieval Fantasy City Generator](https://watabou.itch.io/medieval-fantasy-city-generator). \[laughter\]
 
 **Mikeal Rogers:** That's awesome.
 


### PR DESCRIPTION
Removes most unintelligibles from `js-party-13.md` (some of these don't seem recoverable, as the audio is dropped/missing), `go-time-3.md`, and `go-time-5.md`. Additionally, I populated a few links to various tools/projects discussed in the episodes!