### PR TITLE
Fix timestamp formatter to allow for backslashes

### DIFF
--- a/format.js
+++ b/format.js
@@ -9,8 +9,8 @@ const REPLACES = [
     [/\bdev ops/gi, 'DevOps'],
     [/\bclick[ -]ops/g, 'ClickOps'],
 
-    [/\[00:(\d{2}:\d{2}).\d{2}\]/g, '\[$1]'], // Remove leading 00: and fractions in timestamps
-    [/\[(\d{2}:\d{2}).\d{2}\]/g, '\[$1]'], // Remove fractions in timestamps
+    [/\\?\[(00:)?(\d{2}:\d{2})(\.\d{2})?\\?\]/g, '\\[$2\\]'], // Remove leading 00: and fractions in timestamps
+    
     [/\\`(.*?)\\`/g, '`$1`'], // Remove escaping backslashes before backticks
 ]
 

--- a/format.test.js
+++ b/format.test.js
@@ -9,9 +9,15 @@ test('applyReplaces works as expected', () => {
     expect(applyReplaces('I love javascript')).toBe('I love JavaScript')
     expect(applyReplaces('r/javascript')).toBe('r/javascript')
     
-    expect(applyReplaces('\[00:04:06.27\]')).toBe('\[04:06\]')
-    expect(applyReplaces('\[00:10:17.78\]')).toBe('\[10:17\]')
-    expect(applyReplaces('\[03:43.78\]')).toBe('\[03:43\]')
+    expect(applyReplaces('\[00:04:06.27\]')).toBe('\\[04:06\\]')
+    expect(applyReplaces('\[00:10:17.78\]')).toBe('\\[10:17\\]')
+    expect(applyReplaces('\[03:43.78\]')).toBe('\\[03:43\\]')
+    expect(applyReplaces('\\[00:01:46\\]')).toBe('\\[01:46\\]')
+    
+    
+    expect(applyReplaces('\\\[00:04:06.27\\\]')).toBe('\\[04:06\\]')
+    expect(applyReplaces('\\\[00:10:17.78\]')).toBe('\\[10:17\\]')
+    expect(applyReplaces('\[03:43.78\\\]')).toBe('\\[03:43\\]')
     
     expect(applyReplaces("\\`console.log($TOKEN)\\`")).toBe('`console.log($TOKEN)`')
     expect(applyReplaces("The difference between \\`foo\\` and \\`bar\\`")).toBe('The difference between `foo` and `bar`')


### PR DESCRIPTION
Fix timestamp formatter to work on timestamps with escaping `\`'s, i.e. work on `\[00:12:37.22\]` instead of `[00:12:37]`