### PR TITLE
changelog-news-81.md: Fix typo in Tatu Ylonen's name

### DIFF
--- a/news/changelog-news-81.md
+++ b/news/changelog-news-81.md
@@ -66,7 +66,7 @@ It's also [open source](https://github.com/microsoft/sudo), which is how I know 
 
 **Jerod Santo:**
 
-Tatu Ylonenqqq, author of the original SSH, tells the tale of how they got SSH to be port 22.
+Tatu Ylonen, author of the original SSH, tells the tale of how they got SSH to be port 22.
 
 > I wrote the initial version of SSH (Secure Shell) in Spring 1995. It was a time when telnet and FTP were widely used.
 >


### PR DESCRIPTION
There's no "qqq" at the end of Tatu Ylonen's name. See https://ylonen.org/.